### PR TITLE
SAGE-881 fixed raingauge test exitcode

### DIFF
--- a/ROOTFS/etc/waggle/sanity/interactive/rpi_raingauge.test
+++ b/ROOTFS/etc/waggle/sanity/interactive/rpi_raingauge.test
@@ -8,8 +8,9 @@ fi
 cd $(dirname $0)
 
 if ! resp=$(ssh rpi bash -s < rpi_check_raingauge_payload.sh); then
+    exitcode=$?
     echo "Rain Gauge Test: ${resp} FAIL"
-    exit $?
+    exit $exitcode
 fi
 
 echo "Rain Gauge Test: PASS"


### PR DESCRIPTION
The test was losing the exit code after echoing the "test fail" message. I'm storing it before the echo now.