### PR TITLE
SAGE-881 fixed test exitcode

### DIFF
--- a/ROOTFS/etc/waggle/sanity/interactive/10_rpi_raingauge.test
+++ b/ROOTFS/etc/waggle/sanity/interactive/10_rpi_raingauge.test
@@ -8,8 +8,9 @@ fi
 cd $(dirname $0)
 
 if ! resp=$(ssh rpi bash -s < rpi_check_raingauge_payload.sh); then
+    exitcode=$?
     echo "Rain Gauge Test: ${resp} FAIL"
-    exit $?
+    exit $exitcode
 fi
 
 echo "Rain Gauge Test: PASS"


### PR DESCRIPTION
Bug fix: I was losing the rain gauge test exit code after echoing the fail message. This fixes that problem.