### PR TITLE
SAGE-881 fixed exitcode (again)

### DIFF
--- a/ROOTFS/etc/waggle/sanity/interactive/10_rpi_raingauge.test
+++ b/ROOTFS/etc/waggle/sanity/interactive/10_rpi_raingauge.test
@@ -7,10 +7,12 @@ fi
 
 cd $(dirname $0)
 
-if ! resp=$(ssh rpi bash -s < rpi_check_raingauge_payload.sh); then
-    exitcode=$?
+resp=$(ssh rpi bash -s < rpi_check_raingauge_payload.sh)
+exitcode=$?
+
+if [ "$exitcode" -ne 0 ]; then
     echo "Rain Gauge Test: ${resp} FAIL"
-    exit $exitcode
+    exit "$exitcode"
 fi
 
 echo "Rain Gauge Test: PASS"


### PR DESCRIPTION
We had to move the exitcode capture outside of if statement to prevent it from getting lost.