### PR TITLE
SAGE-856: Adding media tests

### DIFF
--- a/ROOTFS/etc/waggle/sanity/fatal/core_nvme_emmc.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/core_nvme_emmc.test
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# nx core tests
+pf="NVME and eMMC tests"
+
+echo "$pf: Begin"
+
+# properly mounted tests 
+if [ "$(df -h | grep "/media/root-ro")" = "" ];
+then
+        echo "$pf: RO partition not mounted FAIL"
+        exit 1
+fi
+
+if [ "$(df -h | grep "/media/root-rw")" = "" ];
+then
+        echo "$pf: RW partition not mounted FAIL"
+        exit 2
+fi
+
+if [ "$(df -h | grep "/media/plugin-data")" = "" ];
+then
+        echo "$pf: plugin-data not mounted FAIL"
+        exit 3
+fi
+
+# fsck pass
+# TODO: add future fsck for nvme0n1p3 259:3 0 s56G 0 part /media/root-rw/
+if [ "$(cat /run/initramfs/fsck.log | grep "/dev/mmcblk0p1: clean")" = "" ];
+then
+        echo "$pf: incorrect fsck pass on nx-core FAIL"
+        exit 4
+fi
+
+
+if [ "$(swapon | grep "/dev/nvme0n1p1")" = "" ];
+then
+        echo "$pf: swap not properly mounted FAIL"
+        exit 5
+fi
+
+if [ "$(file -L /boot/initrd | grep "gzip compressed data")" = "" ];
+then 
+        echo "$pf: initrd is not a valid archive FAIL"
+        exit 6
+fi
+
+if [ "$(file -L /boot/Image | grep data)" = "" ]; 
+then
+        echo "$pf: /boot/Image is not valid FAIL"
+        exit 7
+fi
+
+if [ "$(file -L /boot/Image.sig | grep data)" = "" ]; 
+then
+        echo "$pf: /boot/Image.sig is not valid FAIL"
+        exit 8
+fi
+
+if [ "$(file -L /boot/dtb/tegra194-xavier-nx-cti-NGX003-WAGGLE-WS.dtb | grep "Device Tree Blob")" = "" ];
+then
+        echo "$pf: /boot/dtb/boot/dtb/tegra194-xavier-nx-cti-NGX003-WAGGLE-WS.dtb not valid FAIL"
+        exit 9
+fi
+
+if [ "$(file -L /boot/dtb/tegra194-xavier-nx-cti-NGX003-WAGGLE-WS.dtb.sig | grep "data")" = "" ];
+then
+        echo "$pf: /boot/dtb/boot/dtb/tegra194-xavier-nx-cti-NGX003-WAGGLE-WS.dtb.sig not valid FAIL"
+        exit 10
+fi
+
+
+
+echo "$pf: PASS"
+exit 0 

--- a/ROOTFS/etc/waggle/sanity/fatal/core_rpi.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/core_rpi.test
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+pf="RPI test"
+echo "$pf: Begin"
+
+if [ "$(df -h | grep "/media/rpi")" = "" ];
+then 
+        echo "$pf: RPI not mounted at /media/rpi FAIL"
+        exit 1
+fi
+
+if ! systemctl is-active nfs-server;
+then
+        echo "$pf: nfs-server not running on core FAIL"
+        exit 2
+fi
+
+if ! systemctl is-active dnsmasq; then
+        echo "$pf: dnsmasq is not running on core FAIL"
+        exit 3
+fi
+
+if [ "$(journalctl -b0 | grep "/dev/mmcblk0p11: clean")" = "" ];
+then
+        echo "$pf: fsck did not pass on RPI pxe/nfs partition FAIL"
+        exit 4
+fi
+
+if [ ! -f /etc/waggle/node_manifest.json ];
+then
+        echo "$pf: node_manifest.json does not exist FAIL"
+        exit 5
+fi
+
+if cat /etc/waggle/node_manifest.json | jq .shield.present | grep -q true; then 
+
+        if [ "$(ssh rpi "echo media_echo_test")" != "media_echo_test" ];
+        then 
+                echo "$pf: cannot ssh into RPI FAIL"
+                exit 6
+        fi
+
+        if [ "$(ssh rpi "df -h | grep /media/rpi")" = "" ];
+        then
+                echo "$pf: RPI RO partition not mounted FAIL"
+                exit 7
+        fi
+
+        if [ "$(ssh rpi "df -h | grep root-rw")" = "" ];
+        then
+                echo "$pf: RPI RW partition not mounted FAIL"
+                exit 8
+        fi
+
+        if [ "$(ssh rpi "df -h | grep overlayfs-root")" = "" ];
+        then
+                echo "$pf: RPI overlay partition not mounted FAIL"
+                exit 9
+        fi
+
+        if [ "$(ssh rpi "df -h | grep /media/plugin-data")" = "" ];
+        then
+                echo "$pf: RPI /media/plugin-data partition not mounted FAIL"
+                exit 10
+        fi
+fi
+
+echo "$pf: PASS"
+exit 0 

--- a/ROOTFS/etc/waggle/sanity/fatal/core_sdcard.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/core_sdcard.test
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+pf="Recovery SDCard test"
+echo "$pf: Begin"
+
+
+mount_cleanup () { 
+
+        if [ -d "/tmp/core_sdcard_test/" ]; 
+        then 
+                if mountpoint -q "/tmp/core_sdcard_test" ; 
+                then
+                        umount /tmp/core_sdcard_test/
+                fi
+                rm -r /tmp/core_sdcard_test/
+        fi
+}
+trap 'mount_cleanup' EXIT
+
+
+# run fsck on our sd card
+if ! fsck -nf /dev/mmcblk1p1;
+then
+        echo "$pf: /dev/mmcblk1p1 failed fsck FAIL"
+        exit 1
+fi
+
+if ! fsck -nf /dev/mmcblk1p2;
+then
+        echo "$pf: /dev/mmcblk1p2 failed fsck FAIL"
+        exit 2
+fi
+
+mkdir /tmp/core_sdcard_test
+
+if ! mount -r /dev/mmcblk1p1  /tmp/core_sdcard_test/;
+then 
+        echo "Could not mount /dev/mmcblk1p1 FAIL"
+        exit 3
+fi
+
+if [ "$(cat /tmp/core_sdcard_test/etc/overlayroot.conf | grep "overlayroot=\"tmpfs")" = ""  ];
+then
+        echo "$pf: sdcard tmpfs not properly set up FAIL"
+        exit 4
+fi
+
+
+if ! chroot /tmp/core_sdcard_test ls;
+then
+        echo "$pf: Could not run chroot on sdcard, invalid rootfs FAIL"
+        exit 5
+fi
+
+if [ "$(file -L /tmp/core_sdcard_test/boot/initrd | grep "gzip compressed data")" = "" ];
+then
+        echo "$pf: sdcard initrd is not a valid archive FAIL"
+        exit 6
+fi
+
+if [ "$(file -L /tmp/core_sdcard_test/boot/Image | grep data)" = "" ];
+then
+        echo "$pf: /boot/Image is not valid FAIL"
+        exit 7
+fi
+
+if [ "$(file -L /tmp/core_sdcard_test/boot/Image.sig | grep data)" = "" ];
+then
+        echo "$pf: /boot/Image.sig is not valid FAIL"
+        exit 8
+fi
+
+if [ "$(file -L /tmp/core_sdcard_test/boot/dtb/tegra194-xavier-nx-cti-NGX003-WAGGLE-WS.dtb | grep "Device Tree Blob")" = "" ];
+then
+        echo "$pf: /boot/dtb/tegra194-xavier-nx-cti-NGX003-WAGGLE-WS.dtb not valid FAIL"
+        exit 9
+fi
+
+if [ "$(file -L /tmp/core_sdcard_test/boot/dtb/tegra194-xavier-nx-cti-NGX003-WAGGLE-WS.dtb.sig | grep "data")" = "" ];
+then
+        echo "$pf: /boot/dtb/tegra194-xavier-nx-cti-NGX003-WAGGLE-WS.dtb.sig not valid FAIL"
+        exit 10
+fi
+
+echo "$pf: PASS" 
+exit 0 


### PR DESCRIPTION
Sanity check tests to ensure that our media is operational. 

Problems that need more context, and have been skipped until Joe's return: 

nx core: test valie Image, DTB, ramdisk

recovery:  make sure Image, DTB, ramdisk, do some sanity on the files that a recovery would work

rpi: fsck pass