### PR TITLE
SAGE-1067: only check for existance of GPS device

### DIFF
--- a/ROOTFS/etc/waggle/sanity/fatal/gps.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/gps.test
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-if ! timeout 15 grep -q -m 1 GPGGA /dev/gps; then
-    echo "GPS Test: FAIL"
+testname="GPS Test"
+
+if [ ! -c /dev/gps ]; then
+    echo "$testname: FAIL"
     exit 1
 fi
 
-echo "GPS Test: PASS"
+echo "$testname: PASS"


### PR DESCRIPTION
With the addition of services that send GPS data to Beehive we no longer
can grep for GPS data as it is being "stolen" by `gpsd`.