### PR TITLE
SAGE-1516: remove k3s timeout

### DIFF
--- a/ROOTFS/etc/waggle/sanity/fatal/nxagent_k3s.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/nxagent_k3s.test
@@ -7,7 +7,7 @@ if cat /etc/waggle/node_manifest.json | jq .nxagent.present | grep -q false; the
     exit 0
 fi
 
-if timeout 30s kubectl get nodes --request-timeout='30s' | grep ws-nxagent | grep -q ' Ready '; then
+if kubectl get nodes | grep ws-nxagent | grep -q ' Ready '; then
     echo "NX-Agent K3S Node Test: NX-Agent configured and ready as K3S agent PASS"
     exit 0
 fi

--- a/ROOTFS/etc/waggle/sanity/fatal/nxcore_k3s.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/nxcore_k3s.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "NX-Core K3S Node Test: Begin"
 
-if timeout 30s kubectl get nodes | grep ws-nxcore | grep ' Ready ' | grep -q control-plane,master; then
+if kubectl get nodes | grep ws-nxcore | grep ' Ready ' | grep -q control-plane,master; then
     echo "NX-Core K3S Node Test: NX-Core configured and ready as K3S master PASS"
     exit 0
 fi

--- a/ROOTFS/etc/waggle/sanity/fatal/rpi_k3s.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/rpi_k3s.test
@@ -7,7 +7,7 @@ if cat /etc/waggle/node_manifest.json | jq .shield.present | grep -q false; then
     exit 0
 fi
 
-if timeout 30s kubectl get nodes --request-timeout='30s' | grep ws-rpi | grep -q ' Ready '; then
+if kubectl get nodes | grep ws-rpi | grep -q ' Ready '; then
     echo "RPi K3S Node Test: RPi configured and ready as K3S agent PASS"
     exit 0
 fi


### PR DESCRIPTION
We don't care how long the test takes to pass and will trust in the overall test execution timeout.