### PR TITLE
SAGE-1398: account for possible 'null' on daemonset 'status'

### DIFF
--- a/ROOTFS/etc/waggle/sanity/_helper/wes_daemonset.test
+++ b/ROOTFS/etc/waggle/sanity/_helper/wes_daemonset.test
@@ -11,11 +11,11 @@ pod="$2"
 
 # get the count of available (i.e. running) pods for the daemonset (count of ready)
 ## ex. 3
-numPodsAvailable=$(kubectl get ds $pod -o json | jq -r ."status"."numberAvailable")
+numPodsAvailable=$(kubectl get ds $pod -o json | jq -r ."status"."numberAvailable // empty")
 
 # The number of nodes that are running the daemon pod, but are not supposed to run the daemon (i.e. on terminated nodes)
 ## ex. 0
-numPodsExtra=$(kubectl get ds $pod -o json | jq -r ."status"."numberMisscheduled")
+numPodsExtra=$(kubectl get ds $pod -o json | jq -r ."status"."numberMisscheduled // empty")
 
 # get list of "Ready" nodes
 ## ex. 000048b02d0766be.ws-nxcore
@@ -27,16 +27,26 @@ readarray -t nodes <<<"$search"
 search=$(kubectl get pod | grep $pod | grep " Running" | cut -d' ' -f1)
 readarray -t pods <<<"$search"
 
-# test the number of available pods matches the found "Running" pods
-if [ $numPodsAvailable -ne ${#pods[@]} ]; then
-    echo "$pf: Available pod count ($numPodsAvailable) does not match count of 'Running' pods (${#pods[@]}), FAIL"
-    exit 2
+if [ -z $numPodsAvailable ]; then
+    # sometimes the result can be empty, warn and move on as this test is mostly optional
+    echo "$pf: Available pod count returned 'null', skipping 'Running' pods validation, WARNING"
+else
+    # test the number of available pods matches the found "Running" pods
+    if [ $numPodsAvailable -ne ${#pods[@]} ]; then
+        echo "$pf: Available pod count ($numPodsAvailable) does not match count of 'Running' pods (${#pods[@]}), FAIL"
+        exit 2
+    fi
 fi
 
-# test the number of misscheduled pods
-if [ $numPodsExtra -ne 0 ]; then
-    echo "$pf: Mis-scheduled pods ($numPodsExtra) detected, FAIL"
-    exit 3
+if [ -z $numPodsExtra ]; then
+    # sometimes the result can be empty, warn and move on as this test is mostly optional
+    echo "$pf: Mis-scheduled pod count returned 'null', skipping validation, WARNING"
+else
+    # test the number of misscheduled pods
+    if [ $numPodsExtra -ne 0 ]; then
+        echo "$pf: Mis-scheduled pods ($numPodsExtra) detected, FAIL"
+        exit 3
+    fi
 fi
 
 # test that each pod contains a node in the node array


### PR DESCRIPTION
Occasionally, (not sure when) the 'status' fields can return 'null' causing for a script crash ('null' is not an Integer). So, we now check for that and skip the tests (that were mostly optional anyway).