### PR TITLE
SAGE-1581: fix incorrect skipping of tests (ex. RPi)

### DIFF
--- a/ROOTFS/etc/waggle/sanity/fatal/agent-present.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/agent-present.test
@@ -3,7 +3,7 @@
 echo "Agent Present Test: Begin"
 
 # find all the nx agent serial_no and count them
-expectedAgent=$(cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select(.name == "nxagent").serial_no' | wc -l)
+expectedAgent=$(cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select((.hardware.hardware|startswith("xaviernx")) and (.zone == "agent")).serial_no' | wc -l)
 
 if [[ $expectedAgent == 0 ]]; then
     echo "Agent Present Test: No agent expected for this device PASS"

--- a/ROOTFS/etc/waggle/sanity/fatal/agent_conn.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/agent_conn.test
@@ -3,7 +3,7 @@
 echo "Agent Connection Test: Begin"
 
 # find all the nx agent serial_no and count them
-expectedAgent=$(cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select(.name == "nxagent").serial_no' | wc -l)
+expectedAgent=$(cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select((.hardware.hardware|startswith("xaviernx")) and (.zone == "agent")).serial_no' | wc -l)
 
 if [[ $expectedAgent == 0 ]]; then
     echo "Agent Connection Test: No agent expected for this device PASS"

--- a/ROOTFS/etc/waggle/sanity/fatal/check_hanwha_camera.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/check_hanwha_camera.test
@@ -23,6 +23,8 @@ BAD_RESPONSE = 5
 RESERVED2 = 6
 RESERVED3 = 7
 
+CAMERA_MODELS = ["XNV-8082R", "XNV-8080R", "XNP-6400RW", "XNF-8010RV", "XNV-8081Z"]
+
 
 def print_log(msg, is_pass, title="Hanwha camera test"):
     if is_pass:
@@ -41,7 +43,7 @@ def read_camera_manifest(path="/etc/waggle/node-manifest-v2.json"):
         except:
             raise IOError(f"Failed to load the manifest: {path}")
 
-        return [s for s in manifest["sensors"] if "camera" in s["name"]]
+        return [s for s in manifest["sensors"] if s["hardware"]["hw_model"] in CAMERA_MODELS]
 
 
 def http_request(url, user="waggle", pw="a2kWe89wak3na7@", timeout=5):

--- a/ROOTFS/etc/waggle/sanity/fatal/core_rpi.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/core_rpi.test
@@ -39,7 +39,7 @@ then
         echo "$pf: ${MANIFEST_FILE} does not exist FAIL"
         exit 31
 fi
-if cat ${MANIFEST_FILE} | jq -r '.computes[] | select(.name == "rpi-shield")' | grep -q serial_no; then
+if cat ${MANIFEST_FILE} | jq -r '.computes[] | select((.hardware.hardware|startswith("rpi")) and (.zone == "shield"))' | grep -q serial_no; then
 
         if [ "$(ssh ws-rpi "echo media_echo_test")" != "media_echo_test" ];
         then

--- a/ROOTFS/etc/waggle/sanity/fatal/modem0_status.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/modem0_status.test
@@ -8,7 +8,7 @@ fail() { echo "$testname: $2 FAIL"; exit "$1"; }
 echo "$testname: Begin"
 
 # check system manifest to see if this test needs to be done.
-if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.resources[] | select(.name == "modem")' | grep -q name; then
+if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.resources[] | select((.hardware.hardware == "modem"))' | grep -q name; then
     pass "modem not required by manifest"
 fi
 
@@ -31,7 +31,7 @@ fi
 if echo "$modeminfo" | grep -q 'modem.generic.state-failed-reason.* --'; then
     pass "modem not connected but not in a failed state."
 elif echo "$modeminfo" | grep -q 'modem.generic.state-failed-reason.* sim-missing'; then
-    if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.resources[] | select(.name == "modem-sim")' | grep -q name; then
+    if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.resources[] | select((.hardware.hardware|startswith("modem-sim")))' | grep -q name; then
         pass "modem sim not required by manifest - this is considered an allowed state."
     else
         fail 4 "failed to find sim card"

--- a/ROOTFS/etc/waggle/sanity/fatal/nxagent_k3s.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/nxagent_k3s.test
@@ -2,7 +2,7 @@
 echo "NX-Agent K3S Node Test: Begin"
 
 # read the system manifest to see if this system is to have an NX-Agent
-if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select(.name == "nxagent")' | grep -q serial_no; then
+if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select((.hardware.hardware|startswith("xaviernx")) and (.zone == "agent"))' | grep -q serial_no; then
     echo "NX-Agent K3S Node Test: NX-Agent not installed in this node, assumed PASS"
     exit 0
 fi

--- a/ROOTFS/etc/waggle/sanity/fatal/psu_status.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/psu_status.test
@@ -67,7 +67,7 @@ echo "$pf: PG2 set to $( cat $gpiopath/gpio$pg2/value )"
 echo "$pf: PG3 set to $( cat $gpiopath/gpio$pg3/value )"
 echo "$pf: PG4 set to $( cat $gpiopath/gpio$pg4/value )"
 
-psumodel=$(cat /etc/waggle/node-manifest-v2.json | jq -r '.resources[] | select(.name == "psu").hardware.hardware')
+psumodel=$(cat /etc/waggle/node-manifest-v2.json | jq -r '.resources[] | select(.hardware.hardware|startswith("psu")).hardware.hardware')
 
 isEPPresent=
 if [[ "$psumodel" == "psu-bbbd" ]]; then

--- a/ROOTFS/etc/waggle/sanity/fatal/rpi-present.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/rpi-present.test
@@ -3,7 +3,7 @@
 echo "RPi Present Test: Begin"
 
 # find all the rpi (shield) serial_no and count them
-expectedRPi=$(cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select(.name == "rpi-shield").serial_no' | wc -l)
+expectedRPi=$(cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select((.hardware.hardware|startswith("rpi")) and (.zone == "shield")).serial_no' | wc -l)
 
 if [[ $expectedRPi == 0 ]]; then
     echo "RPi Present Test: No shield expected for this device PASS"

--- a/ROOTFS/etc/waggle/sanity/fatal/rpi_bme680.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/rpi_bme680.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select(.name == "rpi-shield")' | grep -q serial_no; then
+if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select((.hardware.hardware|startswith("rpi")) and (.zone == "shield"))' | grep -q serial_no; then
     echo "RPi BME680 Test: Stevenson Shield not installed in this node, assume PASS"
     exit 0
 fi

--- a/ROOTFS/etc/waggle/sanity/fatal/rpi_conn.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/rpi_conn.test
@@ -3,7 +3,7 @@
 echo "RPi Connection Test: Begin"
 
 # find all the rpi (shield) serial_no and count them
-expectedRPi=$(cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select(.name == "rpi-shield").serial_no' | wc -l)
+expectedRPi=$(cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select((.hardware.hardware|startswith("rpi")) and (.zone == "shield")).serial_no' | wc -l)
 
 if [[ $expectedRPi == 0 ]]; then
     echo "RPi Present Test: No shield expected for this device PASS"

--- a/ROOTFS/etc/waggle/sanity/fatal/rpi_k3s.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/rpi_k3s.test
@@ -2,7 +2,7 @@
 echo "RPi K3S Node Test: Begin"
 
 # read the system manifest to see if this system is to have a Stevenson Shield
-if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select(.name == "rpi-shield")' | grep -q serial_no; then
+if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select((.hardware.hardware|startswith("rpi")) and (.zone == "shield"))' | grep -q serial_no; then
     echo "RPi K3S Node Test: Stevenson Shield not installed in this node, assume PASS"
     exit 0
 fi

--- a/ROOTFS/etc/waggle/sanity/fatal/rpi_mic.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/rpi_mic.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select(.name == "rpi-shield")' | grep -q serial_no; then
+if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select((.hardware.hardware|startswith("rpi")) and (.zone == "shield"))' | grep -q serial_no; then
     echo "RPi Mic Test: Stevenson Shield not installed in this node, assume PASS"
     exit 0
 fi

--- a/ROOTFS/etc/waggle/sanity/fatal/rpi_raingauge.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/rpi_raingauge.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select(.name == "rpi-shield")' | grep -q serial_no; then
+if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select((.hardware.hardware|startswith("rpi")) and (.zone == "shield"))' | grep -q serial_no; then
     echo "RPi Rain Gauge Test: Stevenson Shield not installed in this node, assume PASS"
     exit 0
 fi

--- a/ROOTFS/etc/waggle/sanity/fatal/wes_audio_server.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/wes_audio_server.test
@@ -2,7 +2,7 @@
 
 pf="WES Audio Server Test"
 
-if cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select(.name == "rpi-shield")' | grep -q serial_no; then
+if cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select((.hardware.hardware|startswith("rpi")) and (.zone == "shield"))' | grep -q serial_no; then
     /etc/waggle/sanity/_helper/wes_deployment.test "$pf" "wes-audio-server" "ws-rpi"
 else
     echo "$pf: Stevenson Shield not installed in this node, skip test"

--- a/ROOTFS/etc/waggle/sanity/fatal/wifi0_status.test
+++ b/ROOTFS/etc/waggle/sanity/fatal/wifi0_status.test
@@ -8,7 +8,7 @@ fail() { echo "$testname: $2 FAIL"; exit "$1"; }
 echo "$testname: Begin"
 
 # check system manifest to see if this test needs to be done.
-if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.resources[] | select(.name == "wifi")' | grep -q name; then
+if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.resources[] | select(.hardware.hardware == "wifi")' | grep -q name; then
     pass "wifi not required by manifest"
 fi
 

--- a/ROOTFS/etc/waggle/sanity/interactive/10_rpi_raingauge.test
+++ b/ROOTFS/etc/waggle/sanity/interactive/10_rpi_raingauge.test
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select(.name == "rpi-shield")' | grep -q serial_no; then
+if ! cat /etc/waggle/node-manifest-v2.json | jq -r '.computes[] | select((.hardware.hardware|startswith("rpi")) and (.zone == "shield"))' | grep -q serial_no; then
     echo "RPi Rain Gauge Test: Stevenson Shield not installed in this node, assume PASS"
     exit 0
 fi

--- a/ROOTFS/etc/waggle/sanity/interactive/99_psu_control.test
+++ b/ROOTFS/etc/waggle/sanity/interactive/99_psu_control.test
@@ -5,7 +5,7 @@
 pf="Power Supply Control Interactive Test"
 echo "$pf: Begin"
 
-psumodel=$(cat /etc/waggle/node-manifest-v2.json | jq -r '.resources[] | select(.name == "psu").hardware.hardware')
+psumodel=$(cat /etc/waggle/node-manifest-v2.json | jq -r '.resources[] | select(.hardware.hardware|startswith("psu")).hardware.hardware')
 
 ep_supply=
 if [[ "$psumodel" == "psu-bbbd" ]]; then


### PR DESCRIPTION
Change from matching on the 'name' field in in the new cloud manifest as this 'name' field is free-form and doesn't have to be anything specific. Instead use the (more static) fields in .hardware to identify hardware compute, sensors and resources.